### PR TITLE
Change link to My FavouriteSandwich to be http

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ should run under the hosting environment of your preference.
 
 ## Credit
 
-Concept + Design(kinda): https://myfavouritesandwich.org/
+Concept + Design(kinda): http://myfavouritesandwich.org/

--- a/static/index.html
+++ b/static/index.html
@@ -99,7 +99,7 @@
         details.  (a <a href="http://mozillalabs.com">mozilla labs</a> thing).
 
         <small>
-          (Thanks to the <a href="https://myfavouritesandwich.org">unhosted dudes</a> for the favorite meme)
+          (Thanks to the <a href="http://myfavouritesandwich.org">unhosted dudes</a> for the favorite meme)
         </small>
 
       </div>


### PR DESCRIPTION
We want to move our demo app to be a client-side app, and have it hosted on a http-only service. We would be grateful if you could update the link here as well!

Cheers,
Michiel
